### PR TITLE
Fix qt build on windows

### DIFF
--- a/builds/qt/czmq.pri
+++ b/builds/qt/czmq.pri
@@ -57,5 +57,9 @@ INCLUDEPATH += \
 }
 
 win32 {
+    INCLUDEPATH += \
+        $$PWD/windows \
+        $$PWD/../../src
+
     LIBS += -L$$C:/Windows/System32 -lrpcrt4
 }

--- a/builds/qt/windows/platform.h
+++ b/builds/qt/windows/platform.h
@@ -1,0 +1,6 @@
+/* #undef HAVE_LINUX_WIRELESS_H */
+/* #undef HAVE_NET_IF_H */
+/* #undef HAVE_NET_IF_MEDIA_H */
+/* #undef HAVE_GETIFADDRS */
+/* #undef HAVE_FREEIFADDRS */
+#define HAVE_DECL_AI_V4MAPPED 0


### PR DESCRIPTION
Fix qt pri build on windows to be able to build ingescape with the dependencies included by their pri files.